### PR TITLE
Add FPS and Resolution Settings

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -341,6 +341,8 @@ app.commandLine.appendSwitch(
         "WaylandWindowDecorations",
         "AcceleratedVideoDecodeLinuxGL",
         "VaapiVideoDecoder",
+        "AcceleratedVideoDecodeLinuxZeroCopyGL",
+        "VaapiIgnoreDriverChecks",
     ].join(",")
 );
 

--- a/src/overlay/components/settingsSection.tsx
+++ b/src/overlay/components/settingsSection.tsx
@@ -41,8 +41,7 @@ const resolutionOptions = [
 
 const fpsOptions = [
     { label: "60 FPS", value: 60 },
-    { label: "120 FPS", value: 120 },
-    { label: "240 FPS", value: 240 },
+    { label: "120 FPS", value: 120 }
 ];
 
 export const SettingsSection: React.FC<SettingsSectionProps> = ({

--- a/src/overlay/components/settingsSection.tsx
+++ b/src/overlay/components/settingsSection.tsx
@@ -35,9 +35,9 @@ const userAgentOptions = [
 
 // New options
 const resolutionOptions = [
-    { label: "1366 x 720 (30 FPS)", value: "1366x768" },
-    { label: "1920 x 1080 (60, 120 FPS)", value: "1920x1080" },
-    { label: "2560 x 1440 (60, 120 FPS)", value: "2560x1440" },
+    { label: "1366 x 768", value: "1366x768" },
+    { label: "1920 x 1080", value: "1920x1080" },
+    { label: "2560 x 1440", value: "2560x1440" },
 ];
 
 const fpsOptions = [
@@ -110,15 +110,6 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
                 monitorWidth: w,
                 monitorHeight: h,
             };
-            // Make sure user can't set wrong FPS to resolution.
-            if (w === 1366 && h === 768) {
-                nextConfig.framesPerSecond = 30;
-            } else {
-                if (config.framesPerSecond === 30) {
-                    nextConfig.framesPerSecond = 60;
-                }
-            }
-
             setConfig(nextConfig);
         }
     };

--- a/src/overlay/components/settingsSection.tsx
+++ b/src/overlay/components/settingsSection.tsx
@@ -33,6 +33,18 @@ const userAgentOptions = [
     },
 ];
 
+// New options
+const resolutionOptions = [
+    { label: "1920 x 1080", value: "1920x1080" },
+    { label: "2560 x 1440", value: "2560x1440" },
+];
+
+const fpsOptions = [
+    { label: "60 FPS", value: 60 },
+    { label: "120 FPS", value: 120 },
+    { label: "240 FPS", value: 240 },
+];
+
 export const SettingsSection: React.FC<SettingsSectionProps> = ({
     config,
     setConfig,
@@ -58,7 +70,18 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
             : "";
     };
 
-    //console.log(getColor);
+    const getResolutionValue = () => {
+        const current = `${config.monitorWidth}x${config.monitorHeight}`;
+        return resolutionOptions.some((r) => r.value === current)
+            ? current
+            : resolutionOptions[0].value;
+    };
+
+    const getFpsValue = () => {
+        return fpsOptions.some((f) => f.value === config.framesPerSecond)
+            ? config.framesPerSecond
+            : fpsOptions[0].value;
+    };
 
     const handleToggle = (key: keyof Config) => {
         const updatedConfig = { ...config, [key]: !config[key] };
@@ -73,6 +96,22 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
     const handleUserAgentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const updated = { ...config, userAgent: e.target.value };
         setConfig(updated);
+    };
+
+    const handleResolutionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const [wStr, hStr] = e.target.value.split("x");
+        const w = Number(wStr);
+        const h = Number(hStr);
+        if (!Number.isNaN(w) && !Number.isNaN(h)) {
+            setConfig({ ...config, monitorWidth: w, monitorHeight: h });
+        }
+    };
+
+    const handleFpsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const fps = Number(e.target.value);
+        if (!Number.isNaN(fps)) {
+            setConfig({ ...config, framesPerSecond: fps });
+        }
     };
 
     /*const onToggle = (key: keyof Config, value: boolean) => {
@@ -143,6 +182,53 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
                         ))}
                     </select>
                 </label>
+                <label className="flex items-center justify-between">
+                    <span>
+                        Resolution
+                        <div className="relative group inline-block">
+                            <FaInfoCircle className="ml-2 cursor-pointer peer" />
+                            <div className="absolute bottom-full left-1/2 -translate-x-1/2 ml-8 mb-2 px-3 py-1 rounded-md bg-gray-500 text-white text-base opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
+                                Select the target monitor resolution
+                                <br />
+                                used for streaming.
+                            </div>
+                        </div>
+                    </span>
+                    <select
+                        value={getResolutionValue()}
+                        onChange={handleResolutionChange}
+                        className="rounded p-2 bg-[#23272b] border border-gray-600 ml-4 text-white"
+                    >
+                        {resolutionOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex items-center justify-between">
+                    <span>
+                        FPS
+                        <div className="relative group inline-block">
+                            <FaInfoCircle className="ml-2 cursor-pointer peer" />
+                            <div className="absolute bottom-full left-1/2 -translate-x-1/2 ml-8 mb-2 px-3 py-1 rounded-md bg-gray-500 text-white text-base opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
+                                Select the target frame rate.
+                            </div>
+                        </div>
+                    </span>
+                    <select
+                        value={getFpsValue()}
+                        onChange={handleFpsChange}
+                        className="rounded p-2 bg-[#23272b] border border-gray-600 ml-4 text-white"
+                    >
+                        {fpsOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
                 <label className="flex items-center justify-between">
                     <span>
                         Discord Rich Presence

--- a/src/overlay/components/settingsSection.tsx
+++ b/src/overlay/components/settingsSection.tsx
@@ -35,13 +35,15 @@ const userAgentOptions = [
 
 // New options
 const resolutionOptions = [
-    { label: "1920 x 1080", value: "1920x1080" },
-    { label: "2560 x 1440", value: "2560x1440" },
+    { label: "1366 x 720 (30 FPS)", value: "1366x768" },
+    { label: "1920 x 1080 (60, 120 FPS)", value: "1920x1080" },
+    { label: "2560 x 1440 (60, 120 FPS)", value: "2560x1440" },
 ];
 
 const fpsOptions = [
+    { label: "30 FPS", value: 30 },
     { label: "60 FPS", value: 60 },
-    { label: "120 FPS", value: 120 }
+    { label: "120 FPS - Ultimate Only", value: 120 }
 ];
 
 export const SettingsSection: React.FC<SettingsSectionProps> = ({
@@ -101,8 +103,23 @@ export const SettingsSection: React.FC<SettingsSectionProps> = ({
         const [wStr, hStr] = e.target.value.split("x");
         const w = Number(wStr);
         const h = Number(hStr);
+
         if (!Number.isNaN(w) && !Number.isNaN(h)) {
-            setConfig({ ...config, monitorWidth: w, monitorHeight: h });
+            const nextConfig: Config = {
+                ...config,
+                monitorWidth: w,
+                monitorHeight: h,
+            };
+            // Make sure user can't set wrong FPS to resolution.
+            if (w === 1366 && h === 768) {
+                nextConfig.framesPerSecond = 30;
+            } else {
+                if (config.framesPerSecond === 30) {
+                    nextConfig.framesPerSecond = 60;
+                }
+            }
+
+            setConfig(nextConfig);
         }
     };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,9 @@ export const defaultConfig: Config = {
     informed: false,
     accentColor: "",
     inactivityNotification: false,
+    monitorWidth: 1920,
+    monitorHeight: 1080,
+    framesPerSecond: 60
 };
 
 export interface Config {
@@ -20,6 +23,9 @@ export interface Config {
     informed: boolean;
     accentColor: string;
     inactivityNotification: boolean;
+    monitorWidth: number;
+    monitorHeight: number;
+    framesPerSecond: number;
 }
 
 export interface UserContext {

--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -32,6 +32,9 @@ export async function syncFromCloud() {
             autofocus: data.gfiautofocus ?? false,
             automute: data.gfiautomute ?? false,
             informed: data.gfinformed ?? false,
+            monitorWidth: data.gfimonwidth ?? 1920,
+            monitorHeight: data.gfimonheight ?? 1080,
+            framesPerSecond: data.gfifps ?? 60
         };
 
         // Save to disk via exposed IPC
@@ -65,6 +68,9 @@ export async function syncToCloud(config: Config) {
             gfiautomute: config.automute,
             gfinformed: config.informed,
             patreonSub: false,
+            gfimonwidth: config.monitorWidth,
+            gfimonheight: config.monitorHeight,
+            gfifps: config.framesPerSecond
         };
 
         await setDoc(docRef, userData, { merge: true });


### PR DESCRIPTION
Allows selecting 1920x1080 or 2560x1440, with FPS selection as 60, and 120.
These are added as config options and elements also added to the overlay.

240 FPS technically can work, but I guess this is limited to AV1 encoding/Windows-specific implementation which I have not looked into.

Source for changes: https://gist.github.com/a9udn9u/85e0c8e863db85c5b62320766bd7b2e9#file-pac-script-js


## Screenshots
2560x1440 at 120 FPS (my screens are 1080p):
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a29c0ec-3459-4b85-8cab-8572f0a28cfa" />


1920x1080 at 120 FPS (my screens are 1080p):
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9f807a2f-0306-4ebc-b2a6-30193c88ceee" />


